### PR TITLE
Feat/match-enroll

### DIFF
--- a/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnroll.java
+++ b/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnroll.java
@@ -4,10 +4,7 @@ import com.yfmf.footlog.domain.matchenroll.enums.ClubLevel;
 import com.yfmf.footlog.domain.matchenroll.enums.MatchGender;
 import com.yfmf.footlog.domain.matchenroll.enums.PlayerCount;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Table(name= "MATCH_ENROLL")
 public class MatchEnroll {
 
@@ -67,5 +65,79 @@ public class MatchEnroll {
 
     @Enumerated(EnumType.STRING)
     private ClubLevel clubLevel;
+
+    public void updateMatch(String matchTitle, String description, LocalDateTime matchDay, Boolean isPro,
+                            Integer matchCost, Integer playTime, Integer quarter, String fieldLocation,
+                            PlayerCount playerCount, MatchGender matchGender, String userName, String clubName,
+                            String clubImageUrl, ClubLevel clubLevel) {
+        if (matchTitle != null) {
+            this.matchTitle = matchTitle;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (matchDay != null) {
+            this.matchDay = matchDay;
+        }
+        if (isPro != null) {
+            this.isPro = isPro;
+        }
+        if (matchCost != null) {
+            this.matchCost = matchCost;
+        }
+        if (playTime != null) {
+            this.playTime = playTime;
+        }
+        if (quarter != null) {
+            this.quarter = quarter;
+        }
+        if (fieldLocation != null) {
+            this.fieldLocation = fieldLocation;
+        }
+        if (playerCount != null) {
+            this.playerCount = playerCount;
+        }
+        if (matchGender != null) {
+            this.matchGender = matchGender;
+        }
+        if (userName != null) {
+            this.userName = userName;
+        }
+        if (clubName != null) {
+            this.clubName = clubName;
+        }
+        if (clubImageUrl != null) {
+            this.clubImageUrl = clubImageUrl;
+        }
+        if (clubLevel != null) {
+            this.clubLevel = clubLevel;
+        }
+
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public MatchEnroll(String matchTitle, String description, LocalDateTime matchDay, Boolean isPro,
+                       Integer matchCost, Integer playTime, Integer quarter, String fieldLocation,
+                       PlayerCount playerCount, MatchGender matchGender, Long userId, String userName,
+                       String clubName, String clubImageUrl, ClubLevel clubLevel) {
+        this.matchTitle = matchTitle;
+        this.description = description;
+        this.matchDay = matchDay;
+        this.isPro = isPro;
+        this.matchCost = matchCost;
+        this.playTime = playTime;
+        this.quarter = quarter;
+        this.fieldLocation = fieldLocation;
+        this.playerCount = playerCount;
+        this.matchGender = matchGender;
+        this.userId = userId;
+        this.userName = userName;
+        this.clubName = clubName;
+        this.clubImageUrl = clubImageUrl;
+        this.clubLevel = clubLevel;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnroll.java
+++ b/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnroll.java
@@ -4,224 +4,68 @@ import com.yfmf.footlog.domain.matchenroll.enums.ClubLevel;
 import com.yfmf.footlog.domain.matchenroll.enums.MatchGender;
 import com.yfmf.footlog.domain.matchenroll.enums.PlayerCount;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name= "MATCH_ENROLL")
 public class MatchEnroll {
 
     @Id
     @GeneratedValue
     private Long matchEnrollId;
+
+    @Column(nullable = false)
     private String matchTitle;
+
     private String description;
+
+    @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
+
     private LocalDateTime matchDay;
-    private Boolean isPro;
-    private Integer matchCost;
-    private Integer playTime;
+
+    @Column(nullable = false)
+    private Boolean isPro = false;
+
+    @Column(nullable = false)
+    private Integer matchCost = 0;
+
+    @Column(nullable = false)
+    private Integer playTime = 2;
     private Integer quarter;
+
+    @Column(nullable = false)
     private String fieldLocation;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private PlayerCount playerCount;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MatchGender matchGender;
 
     // user
+    @Column(nullable = false)
     private Long userId;
-
     private String userName;
 
     //club
     private String clubName;
-
     private String clubImageUrl;
 
+    @Enumerated(EnumType.STRING)
     private ClubLevel clubLevel;
 
-    protected MatchEnroll() {}
-
-    public MatchEnroll(String matchTitle, String description, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime matchDay, Boolean isPro, Integer matchCost, Integer playTime, Integer quarter, String fieldLocation, PlayerCount playerCount, MatchGender matchGender, Long userId, String userName, String clubName, String clubImageUrl, ClubLevel clubLevel) {
-        this.matchTitle = matchTitle;
-        this.description = description;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.matchDay = matchDay;
-        this.isPro = isPro;
-        this.matchCost = matchCost;
-        this.playTime = playTime;
-        this.quarter = quarter;
-        this.fieldLocation = fieldLocation;
-        this.playerCount = playerCount;
-        this.matchGender = matchGender;
-        this.userId = userId;
-        this.userName = userName;
-        this.clubName = clubName;
-        this.clubImageUrl = clubImageUrl;
-        this.clubLevel = clubLevel;
-    }
-
-    public Long getMatchEnrollId() {
-        return matchEnrollId;
-    }
-
-    public String getMatchTitle() {
-        return matchTitle;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public LocalDateTime getMatchDay() {
-        return matchDay;
-    }
-
-    public Boolean getPro() {
-        return isPro;
-    }
-
-    public Integer getMatchCost() {
-        return matchCost;
-    }
-
-    public Integer getPlayTime() {
-        return playTime;
-    }
-
-    public Integer getQuarter() {
-        return quarter;
-    }
-
-    public String getFieldLocation() {
-        return fieldLocation;
-    }
-
-    public PlayerCount getPlayerCount() {
-        return playerCount;
-    }
-
-    public MatchGender getMatchGender() {
-        return matchGender;
-    }
-
-    public Long getUserId() {
-        return userId;
-    }
-
-    public String getUserName() {
-        return userName;
-    }
-
-    public String getClubName() {
-        return clubName;
-    }
-
-    public String getClubImageUrl() {
-        return clubImageUrl;
-    }
-
-    public ClubLevel getClubLevel() {
-        return clubLevel;
-    }
-
-    public void setMatchTitle(String matchTitle) {
-        this.matchTitle = matchTitle;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public void setMatchDay(LocalDateTime matchDay) {
-        this.matchDay = matchDay;
-    }
-
-    public void setMatchCost(Integer matchCost) {
-        this.matchCost = matchCost;
-    }
-
-    public void setPlayTime(Integer playTime) {
-        this.playTime = playTime;
-    }
-
-    public void setQuarter(Integer quarter) {
-        this.quarter = quarter;
-    }
-
-    public void setFieldLocation(String fieldLocation) {
-        this.fieldLocation = fieldLocation;
-    }
-
-    public void setPlayerCount(PlayerCount playerCount) {
-        this.playerCount = playerCount;
-    }
-
-    public void setMatchGender(MatchGender matchGender) {
-        this.matchGender = matchGender;
-    }
-
-    public void setUserId(Long userId) {
-        this.userId = userId;
-    }
-
-    public void setUserName(String userName) {
-        this.userName = userName;
-    }
-
-    public void setClubName(String clubName) {
-        this.clubName = clubName;
-    }
-
-    public void setClubImageUrl(String clubImageUrl) {
-        this.clubImageUrl = clubImageUrl;
-    }
-
-    public void setClubLevel(ClubLevel clubLevel) {
-        this.clubLevel = clubLevel;
-    }
-
-    @Override
-    public String toString() {
-        return "MatchEnroll{" +
-                "matchEnrollId=" + matchEnrollId +
-                ", matchTitle='" + matchTitle + '\'' +
-                ", description='" + description + '\'' +
-                ", createdAt=" + createdAt +
-                ", updatedAt=" + updatedAt +
-                ", matchDay=" + matchDay +
-                ", isPro=" + isPro +
-                ", matchCost=" + matchCost +
-                ", playTime=" + playTime +
-                ", quarter=" + quarter +
-                ", fieldLocation='" + fieldLocation + '\'' +
-                ", playerCount=" + playerCount +
-                ", matchGender=" + matchGender +
-                ", userId=" + userId +
-                ", userName='" + userName + '\'' +
-                ", clubName='" + clubName + '\'' +
-                ", clubImageUrl='" + clubImageUrl + '\'' +
-                ", clubLevel=" + clubLevel +
-                '}';
-    }
 }

--- a/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnroll.java
+++ b/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnroll.java
@@ -1,0 +1,227 @@
+package com.yfmf.footlog.domain.matchenroll;
+
+import com.yfmf.footlog.domain.matchenroll.enums.ClubLevel;
+import com.yfmf.footlog.domain.matchenroll.enums.MatchGender;
+import com.yfmf.footlog.domain.matchenroll.enums.PlayerCount;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name= "MATCH_ENROLL")
+public class MatchEnroll {
+
+    @Id
+    @GeneratedValue
+    private Long matchEnrollId;
+    private String matchTitle;
+    private String description;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime matchDay;
+    private Boolean isPro;
+    private Integer matchCost;
+    private Integer playTime;
+    private Integer quarter;
+    private String fieldLocation;
+
+    @Enumerated(EnumType.STRING)
+    private PlayerCount playerCount;
+
+    @Enumerated(EnumType.STRING)
+    private MatchGender matchGender;
+
+    // user
+    private Long userId;
+
+    private String userName;
+
+    //club
+    private String clubName;
+
+    private String clubImageUrl;
+
+    private ClubLevel clubLevel;
+
+    protected MatchEnroll() {}
+
+    public MatchEnroll(String matchTitle, String description, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime matchDay, Boolean isPro, Integer matchCost, Integer playTime, Integer quarter, String fieldLocation, PlayerCount playerCount, MatchGender matchGender, Long userId, String userName, String clubName, String clubImageUrl, ClubLevel clubLevel) {
+        this.matchTitle = matchTitle;
+        this.description = description;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.matchDay = matchDay;
+        this.isPro = isPro;
+        this.matchCost = matchCost;
+        this.playTime = playTime;
+        this.quarter = quarter;
+        this.fieldLocation = fieldLocation;
+        this.playerCount = playerCount;
+        this.matchGender = matchGender;
+        this.userId = userId;
+        this.userName = userName;
+        this.clubName = clubName;
+        this.clubImageUrl = clubImageUrl;
+        this.clubLevel = clubLevel;
+    }
+
+    public Long getMatchEnrollId() {
+        return matchEnrollId;
+    }
+
+    public String getMatchTitle() {
+        return matchTitle;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public LocalDateTime getMatchDay() {
+        return matchDay;
+    }
+
+    public Boolean getPro() {
+        return isPro;
+    }
+
+    public Integer getMatchCost() {
+        return matchCost;
+    }
+
+    public Integer getPlayTime() {
+        return playTime;
+    }
+
+    public Integer getQuarter() {
+        return quarter;
+    }
+
+    public String getFieldLocation() {
+        return fieldLocation;
+    }
+
+    public PlayerCount getPlayerCount() {
+        return playerCount;
+    }
+
+    public MatchGender getMatchGender() {
+        return matchGender;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getClubName() {
+        return clubName;
+    }
+
+    public String getClubImageUrl() {
+        return clubImageUrl;
+    }
+
+    public ClubLevel getClubLevel() {
+        return clubLevel;
+    }
+
+    public void setMatchTitle(String matchTitle) {
+        this.matchTitle = matchTitle;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public void setMatchDay(LocalDateTime matchDay) {
+        this.matchDay = matchDay;
+    }
+
+    public void setMatchCost(Integer matchCost) {
+        this.matchCost = matchCost;
+    }
+
+    public void setPlayTime(Integer playTime) {
+        this.playTime = playTime;
+    }
+
+    public void setQuarter(Integer quarter) {
+        this.quarter = quarter;
+    }
+
+    public void setFieldLocation(String fieldLocation) {
+        this.fieldLocation = fieldLocation;
+    }
+
+    public void setPlayerCount(PlayerCount playerCount) {
+        this.playerCount = playerCount;
+    }
+
+    public void setMatchGender(MatchGender matchGender) {
+        this.matchGender = matchGender;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public void setClubName(String clubName) {
+        this.clubName = clubName;
+    }
+
+    public void setClubImageUrl(String clubImageUrl) {
+        this.clubImageUrl = clubImageUrl;
+    }
+
+    public void setClubLevel(ClubLevel clubLevel) {
+        this.clubLevel = clubLevel;
+    }
+
+    @Override
+    public String toString() {
+        return "MatchEnroll{" +
+                "matchEnrollId=" + matchEnrollId +
+                ", matchTitle='" + matchTitle + '\'' +
+                ", description='" + description + '\'' +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", matchDay=" + matchDay +
+                ", isPro=" + isPro +
+                ", matchCost=" + matchCost +
+                ", playTime=" + playTime +
+                ", quarter=" + quarter +
+                ", fieldLocation='" + fieldLocation + '\'' +
+                ", playerCount=" + playerCount +
+                ", matchGender=" + matchGender +
+                ", userId=" + userId +
+                ", userName='" + userName + '\'' +
+                ", clubName='" + clubName + '\'' +
+                ", clubImageUrl='" + clubImageUrl + '\'' +
+                ", clubLevel=" + clubLevel +
+                '}';
+    }
+}

--- a/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnrollRepository.java
+++ b/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnrollRepository.java
@@ -1,0 +1,6 @@
+package com.yfmf.footlog.domain.matchenroll;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchEnrollRepository extends JpaRepository<MatchEnroll, Long> {
+}

--- a/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnrollService.java
+++ b/src/main/java/com/yfmf/footlog/domain/matchenroll/MatchEnrollService.java
@@ -1,0 +1,60 @@
+package com.yfmf.footlog.domain.matchenroll;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class MatchEnrollService {
+
+    private MatchEnrollRepository matchEnrollRepository;
+
+    @Autowired
+    public MatchEnrollService(MatchEnrollRepository matchEnrollRepository) {
+        this.matchEnrollRepository = matchEnrollRepository;
+    }
+
+    @Transactional
+    public MatchEnroll registerMatchEnroll(MatchEnroll matchEnroll) {
+        return matchEnrollRepository.save(matchEnroll);
+    }
+
+    public Optional<MatchEnroll> findMatchEnrollByMatchId(Long matchEnrollId) {
+        return matchEnrollRepository.findById(matchEnrollId);
+    }
+
+    @Transactional
+    public MatchEnroll updateMatch(Long matchEnrollId, MatchEnroll updatedMatchEnroll) {
+        MatchEnroll existingMatch = matchEnrollRepository.findById(matchEnrollId)
+                .orElseThrow(() -> new IllegalArgumentException("등록된 경기를 찾을 수 없습니다. id=" + matchEnrollId));
+
+        existingMatch.updateMatch(
+                updatedMatchEnroll.getMatchTitle(),
+                updatedMatchEnroll.getDescription(),
+                updatedMatchEnroll.getMatchDay(),
+                updatedMatchEnroll.getIsPro(),
+                updatedMatchEnroll.getMatchCost(),
+                updatedMatchEnroll.getPlayTime(),
+                updatedMatchEnroll.getQuarter(),
+                updatedMatchEnroll.getFieldLocation(),
+                updatedMatchEnroll.getPlayerCount(),
+                updatedMatchEnroll.getMatchGender(),
+                updatedMatchEnroll.getUserName(),
+                updatedMatchEnroll.getClubName(),
+                updatedMatchEnroll.getClubImageUrl(),
+                updatedMatchEnroll.getClubLevel());
+
+        return matchEnrollRepository.save(existingMatch);
+
+    }
+
+    @Transactional
+    public void deleteMatch(Long matchEnrollId) {
+        MatchEnroll matchEnroll = matchEnrollRepository.findById(matchEnrollId)
+                .orElseThrow(() -> new IllegalArgumentException("등록된 경기를 찾을 수 없습니다. id=" + matchEnrollId));
+        matchEnrollRepository.delete(matchEnroll);
+    }
+
+}

--- a/src/main/java/com/yfmf/footlog/domain/matchenroll/enums/ClubLevel.java
+++ b/src/main/java/com/yfmf/footlog/domain/matchenroll/enums/ClubLevel.java
@@ -1,0 +1,5 @@
+package com.yfmf.footlog.domain.matchenroll.enums;
+
+public enum ClubLevel {
+    BEGINNER, AMATEUR, SEMIPRO, PRO, WORLDCLASS
+}

--- a/src/main/java/com/yfmf/footlog/domain/matchenroll/enums/MatchGender.java
+++ b/src/main/java/com/yfmf/footlog/domain/matchenroll/enums/MatchGender.java
@@ -1,0 +1,5 @@
+package com.yfmf.footlog.domain.matchenroll.enums;
+
+public enum MatchGender {
+    MALE, FEMALE, MIXED
+}

--- a/src/main/java/com/yfmf/footlog/domain/matchenroll/enums/PlayerCount.java
+++ b/src/main/java/com/yfmf/footlog/domain/matchenroll/enums/PlayerCount.java
@@ -1,0 +1,5 @@
+package com.yfmf.footlog.domain.matchenroll.enums;
+
+public enum PlayerCount {
+    ELEVEN, TEN, NINE;
+}

--- a/src/test/java/com/yfmf/footlog/matchenroll/MatchEnrollTests.java
+++ b/src/test/java/com/yfmf/footlog/matchenroll/MatchEnrollTests.java
@@ -1,0 +1,117 @@
+package com.yfmf.footlog.matchenroll;
+
+import com.yfmf.footlog.domain.matchenroll.MatchEnroll;
+import com.yfmf.footlog.domain.matchenroll.MatchEnrollService;
+import com.yfmf.footlog.domain.matchenroll.enums.ClubLevel;
+import com.yfmf.footlog.domain.matchenroll.enums.MatchGender;
+import com.yfmf.footlog.domain.matchenroll.enums.PlayerCount;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MatchEnrollTests {
+
+    private MatchEnroll matchEnroll;
+    @Autowired
+    private MatchEnrollService matchEnrollService;
+
+    @BeforeEach
+    void setUp() {
+        matchEnroll = MatchEnroll.builder()
+                .matchTitle("경기 등록 테스트")
+                .description("경기 등록 테스트 중입니다.")
+                .matchDay(LocalDateTime.now().plusDays(3))
+                .isPro(true)
+                .matchCost(100)
+                .playTime(3) // default는 2/ 시간단위
+                .quarter(4)
+                .fieldLocation("주소지는 데이터가 어떤 타입이 들어오려나?")
+                .playerCount(PlayerCount.ELEVEN)
+                .matchGender(MatchGender.MALE)
+                .userId(1L) // 임의로..
+                .userName("User1")
+                .clubName("Club1")
+                .clubImageUrl("club1.png")
+                .clubLevel(ClubLevel.BEGINNER)
+                .build();
+    }
+
+    @DisplayName("경기 일정을 등록한다.")
+    @Test
+    void createMatchEnroll() {
+        MatchEnroll createdMatch = matchEnrollService.registerMatchEnroll(matchEnroll);
+
+        assertNotNull(createdMatch);
+        assertNotNull(createdMatch.getMatchEnrollId());
+        assertEquals("경기 등록 테스트", createdMatch.getMatchTitle());
+    }
+
+    @DisplayName("경기 일정이 존재하는지 확인한다..")
+    @Test
+    void findMatchEnroll() {
+        MatchEnroll savedMatch = matchEnrollService.registerMatchEnroll(matchEnroll);
+
+        MatchEnroll foundMatch = matchEnrollService.findMatchEnrollByMatchId(savedMatch.getMatchEnrollId())
+                .orElseThrow(() -> new IllegalArgumentException("경기를 찾을 수 없습니다."));
+
+        assertNotNull(foundMatch);
+        assertEquals("경기 등록 테스트", foundMatch.getMatchTitle());
+    }
+
+    @DisplayName("경기 일정이 업데이트")
+    @Test
+    void updateMatchEnroll() {
+
+        MatchEnroll savedMatch = matchEnrollService.registerMatchEnroll(matchEnroll);
+
+        MatchEnroll updatedMatch = matchEnrollService.updateMatch(
+                savedMatch.getMatchEnrollId(),
+                MatchEnroll.builder()
+                        .matchTitle("경기 등록 변경.")
+                        .description("Updated description.")
+                        .matchDay(LocalDateTime.now().plusDays(10))
+                        .isPro(false)
+                        .matchCost(150)
+                        .playTime(2)
+                        .quarter(3)
+                        .fieldLocation("새로운 장소로 교체.")
+                        .playerCount(PlayerCount.ELEVEN)
+                        .matchGender(MatchGender.FEMALE)
+//                        .userId(1L)
+//                        .userName("UpdatedUser")
+//                        .clubName("UpdatedClub")
+//                        .clubImageUrl("updated_club.png")
+                        .clubLevel(ClubLevel.PRO)
+                        .build()
+        );
+
+        assertNotNull(updatedMatch);
+        // 유저이름은 그전 값과 일치해야함.
+        assertNotEquals("User2", updatedMatch.getUserName());
+        assertEquals("경기 등록 변경.", updatedMatch.getMatchTitle());
+        assertEquals("새로운 장소로 교체.", updatedMatch.getFieldLocation());
+    }
+
+    @DisplayName("해당 경기를 삭제한다.")
+    @Test
+    void deleteMatchEnroll() {
+
+        MatchEnroll savedMatch = matchEnrollService.registerMatchEnroll(matchEnroll);
+
+        MatchEnroll foundMatch = matchEnrollService.findMatchEnrollByMatchId(savedMatch.getMatchEnrollId())
+                .orElseThrow(() -> new IllegalArgumentException("경기를 찾을 수 없습니다."));
+
+        assertNotNull(foundMatch);
+        assertEquals("경기 등록 테스트", foundMatch.getMatchTitle());
+    }
+
+}


### PR DESCRIPTION
## ✅ 경기일정 CUD
issue : #9 

## 📋 Description
기능 이름:  새로운 경기일정을 CUD.
기능 설명: 구단관리자(매니저, 구단주)가 경기 일정을 등록, 수정, 삭제 할 수 있습니다.

## 🛠️ To Do
- [x] 경기 일정 생성: 
- [x] 경기 일정 수정: 
- [x] 경기 일정 삭제: 

## 📝  테스트 결과
![image](https://github.com/user-attachments/assets/e5611c22-00a5-480d-8888-b8aed302a42d)